### PR TITLE
Resolve Alembic migration path via pathlib

### DIFF
--- a/apps/dms/alembic_upgrade.py
+++ b/apps/dms/alembic_upgrade.py
@@ -1,14 +1,28 @@
 import os
+from pathlib import Path
 from sqlalchemy import create_engine, text
 
-SQL_PATH = "/app/database/migrations/versions/0001_init.sql"
-DATABASE_URL = os.getenv("DATABASE_URL","postgresql+psycopg://dmf:dmf@postgres:5432/dmf")
+
+DEFAULT_SQL_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "database"
+    / "migrations"
+    / "versions"
+    / "0001_init.sql"
+)
+SQL_PATH = Path(os.getenv("SQL_PATH", DEFAULT_SQL_PATH))
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql+psycopg://dmf:dmf@postgres:5432/dmf"
+)
+
 
 def upgrade():
     engine = create_engine(DATABASE_URL, future=True)
     with engine.begin() as conn:
-        with open(SQL_PATH, "r", encoding="utf-8") as f:
+        with SQL_PATH.open("r", encoding="utf-8") as f:
             conn.execute(text(f.read()))
+
 
 if __name__ == "__main__":
     upgrade()


### PR DESCRIPTION
## Summary
- resolve migration SQL path relative to alembic_upgrade.py using pathlib
- allow overriding the SQL script location via `SQL_PATH` environment variable

## Testing
- `ruff check apps/dms/alembic_upgrade.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c534c50d4883339949d1325cc668ec