### PR TITLE
Use default_factory for Document model lists and dicts

### DIFF
--- a/libs/schema/models.py
+++ b/libs/schema/models.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, Field
 from typing import Optional, List, Dict
 from datetime import datetime
 
+
 class Document(BaseModel):
     id: str
     title: str
@@ -10,12 +11,13 @@ class Document(BaseModel):
     checksum: str
     mime_type: str
     classification: str = "internal"
-    tags: List[str] = []
-    metadata: Dict[str, str] = {}
+    tags: List[str] = Field(default_factory=list)
+    metadata: Dict[str, str] = Field(default_factory=dict)
     created_by: str
     created_at: datetime
     updated_at: datetime
     current_version_id: Optional[str] = None
+
 
 class DocumentVersion(BaseModel):
     id: str


### PR DESCRIPTION
## Summary
- Replace mutable defaults in `Document` model with `Field(default_factory=...)`.

## Testing
- `ruff format libs/schema/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c534b43c8c8333bd011c035b81626d